### PR TITLE
Fix use of a configuration that conflicts with a Gradle default

### DIFF
--- a/src/main/java/io/spring/gradle/javadoc/JavadocPlugin.java
+++ b/src/main/java/io/spring/gradle/javadoc/JavadocPlugin.java
@@ -41,13 +41,19 @@ import org.gradle.api.tasks.SourceSet;
  */
 public class JavadocPlugin implements Plugin<Project> {
 
+	/**
+	 * A configuration producing the sources that will be used for the aggregate Javadoc
+	 * task.
+	 */
+	public static final String JAVADOC_SOURCES_ELEMENTS_CONFIGURATION_NAME = "javadocSourcesElements";
+
 	@Override
 	public void apply(Project project) {
 		project.getPlugins().withType(JavaPlugin.class).all((javaPlugin) -> withSourcesElements(project));
 	}
 
 	private void withSourcesElements(Project project) {
-		project.getConfigurations().create("sourcesElements", new Action<Configuration>() {
+		project.getConfigurations().create(JAVADOC_SOURCES_ELEMENTS_CONFIGURATION_NAME, new Action<Configuration>() {
 			@Override
 			public void execute(Configuration config) {
 				config.setCanBeResolved(false);


### PR DESCRIPTION
The Gradle sources jar support uses the sourcesElements configuration
to produce its sources jar, which conflicts with the javadoc plugin's use.

When this plugin is used with the `withSourcesJar()` method of creating a sources jar, Gradle will fail to apply the plugin on subprojects.